### PR TITLE
refactor: changes the server code to use tokio spawn and removes the hashmap - closes #22

### DIFF
--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -1,5 +1,5 @@
 use std::io;
-use tokio::net::{TcpListener};
+use tokio::net::TcpListener;
 use tracing::{error, info};
 pub struct Listener {
     //Struct definition

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -1,6 +1,5 @@
 use std::io;
-use std::net::SocketAddr;
-use tokio::net::{TcpListener, TcpStream};
+use tokio::net::{TcpListener};
 use tracing::{error, info};
 pub struct Listener {
     //Struct definition

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -15,18 +15,14 @@ impl Listener {
             let listener = TcpListener::bind("127.0.0.1:8080").await?;
             info!("Listener is running");
             //returns a new listener struct object
-            return Ok(Listener {
-                listener,
-            });
+            return Ok(Listener { listener });
         }
         //If the host and port is specified the server will be ran with the passed address
         let addr = format!("{}:{}", host, port);
         let listener = TcpListener::bind(addr).await?;
         info!("Listener is running");
         //returns a new listener struct
-        Ok(Listener {
-            listener,
-        })
+        Ok(Listener { listener })
     }
     /*pub async fn start_listener(&mut self,host: &str, port: &str){
 
@@ -38,15 +34,11 @@ impl Listener {
             match self.listener.accept().await {
                 //when a connection is made we deal with it below
                 Ok((mut _stream, addr)) => {
-                    info!(
-                        "User {} has connected.",
-                        addr,
-                    );
+                    info!("User {} has connected.", addr,);
 
                     tokio::spawn(async move {
-                        let _ = Listener::handle_client(_stream,addr).await;
+                        //let _ = Listener::handle_client(_stream, addr).await;
                     });
-                    
                 }
 
                 Err(e) => error!(
@@ -78,9 +70,10 @@ impl Listener {
             Ok(msg)
         }
     async fn write_to_stream(&mut stream)-> io::Result<u8>{
-        }*/
-
-        async fn handle_client(stream: TcpStream,addr: SocketAddr) ->io::Result<bool>{
-            Ok(true)
         }
+
+    async fn handle_client(stream: TcpStream, addr: SocketAddr) -> io::Result<bool> {
+        Ok(true)
+    }
+    */
 }

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::io;
 use std::net::SocketAddr;
 use tokio::net::{TcpListener, TcpStream};
@@ -6,7 +5,6 @@ use tracing::{error, info};
 pub struct Listener {
     //Struct definition
     listener: TcpListener,
-    open_connections: HashMap<SocketAddr, TcpStream>,
 }
 
 impl Listener {
@@ -16,11 +14,9 @@ impl Listener {
         if host.is_empty() || port.is_empty() {
             let listener = TcpListener::bind("127.0.0.1:8080").await?;
             info!("Listener is running");
-            let open_connections: HashMap<SocketAddr, TcpStream> = HashMap::new();
             //returns a new listener struct object
             return Ok(Listener {
                 listener,
-                open_connections,
             });
         }
         //If the host and port is specified the server will be ran with the passed address
@@ -28,10 +24,8 @@ impl Listener {
         let listener = TcpListener::bind(addr).await?;
         info!("Listener is running");
         //returns a new listener struct
-        let open_connections: HashMap<SocketAddr, TcpStream> = HashMap::new();
         Ok(Listener {
             listener,
-            open_connections,
         })
     }
     /*pub async fn start_listener(&mut self,host: &str, port: &str){
@@ -42,21 +36,17 @@ impl Listener {
         loop {
             //The listener.accept() function can possibly throw an error so we handle it using the match keyword
             match self.listener.accept().await {
-                //when a connec tion is made we deal with it below
+                //when a connection is made we deal with it below
                 Ok((mut _stream, addr)) => {
-                    if let std::collections::hash_map::Entry::Vacant(e) =
-                        self.open_connections.entry(addr)
-                    {
-                        e.insert(_stream);
-                        //if the current address is already connected
-                        //let welcom_msg = format!("Welcome to the Veriflow Resource Server\n User: {}",addr);
-                        //let write_bytes = _stream.write(welcom_msg.as_bytes()).await?;
-                        info!(
-                            "User {} has connected. Total: {}",
-                            addr,
-                            self.open_connections.len()
-                        );
-                    }
+                    info!(
+                        "User {} has connected.",
+                        addr,
+                    );
+
+                    tokio::spawn(async move {
+                        let _ = Listener::handle_client(_stream,addr).await;
+                    });
+                    
                 }
 
                 Err(e) => error!(
@@ -88,15 +78,9 @@ impl Listener {
             Ok(msg)
         }
     async fn write_to_stream(&mut stream)-> io::Result<u8>{
-        }
-
-        async fn handle_client(stream: TcpStream,) ->io::Result<bool>{
-            tokio::spawn(async move {
-                          if let Err(e) = Listener::read_stream(stream).await{
-                                    let addr = stream.peer_addr();
-                                    error!("Error with {addr}:{e}")
-                                }
-                            });
-            return Ok(true);
         }*/
+
+        async fn handle_client(stream: TcpStream,addr: SocketAddr) ->io::Result<bool>{
+            Ok(true)
+        }
 }


### PR DESCRIPTION
up to date server code using tokio spawn to deal with client connections