### PR TITLE
feat(common): handle error types error types with thiserror

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 [dependencies]
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
+thiserror = "2.0.17"


### PR DESCRIPTION
-  Implement enum for VeriflowError using thiserror to handle IO and Serialisation errors

- closes #24 