### PR TITLE
Refact/common/enums

### DIFF
--- a/client/src/transfer.rs
+++ b/client/src/transfer.rs
@@ -2,8 +2,7 @@
 
 use crate::ui;
 use common::{
-    hashing, protocol::ProtocolConnection, protocol::BUFFER_SIZE, Command, FileHeader,
-    VeriflowError,
+    hashing, protocol::ProtocolConnection, protocol::BUFFER_SIZE, FileHeader, VeriflowError,
 };
 use std::path::Path;
 use tokio::fs::File;
@@ -56,8 +55,7 @@ pub async fn upload_file(path: &Path, ip: &str) -> common::Result<()> {
     let mut connection = ProtocolConnection::new(stream).await?;
 
     // Setup FileHeader
-    let file_header: FileHeader = FileHeader {
-        command: Command::Upload,
+    let file_header: FileHeader = FileHeader::Upload {
         name: String::from(file_name),
         size: file_size,
         hash: file_hash,
@@ -108,16 +106,16 @@ pub async fn upload_file(path: &Path, ip: &str) -> common::Result<()> {
 
     // wait for server response that the file has been successfully uploaded
     println!("Waiting for server confirmation...");
+
     // get prefix
     let prefix_len = connection.read_prefix().await?;
     // get JSON bytes from stream
     let header: Vec<u8> = connection.read_body(prefix_len).await?;
-    // convert bytes into UTF-8 string
-    let string_header = String::from_utf8_lossy(&header);
-    // parse the JSON string back into a fileheader
-    let file_header: FileHeader = serde_json::from_str(&string_header)?;
+    // convert bytes into json
+    let response: FileHeader = serde_json::from_slice(&header)?;
 
-    println!("{}", file_header.name);
+    // Check response
+    response.unpack_response()?;
 
     Ok(())
 }
@@ -140,11 +138,8 @@ pub async fn download_file(path: &Path, ip: &str, download_dir: &Path) -> common
         .ok_or(VeriflowError::InvalidPath)?;
 
     // Setup FileHeader
-    let file_header: FileHeader = FileHeader {
-        command: Command::Download,
+    let file_header: FileHeader = FileHeader::Download {
         name: String::from(file_name),
-        size: 0,             // Unknown size
-        hash: String::new(), // Unknown hash
     };
 
     // Serialise the body
@@ -160,14 +155,15 @@ pub async fn download_file(path: &Path, ip: &str, download_dir: &Path) -> common
     let prefix_len = connection.read_prefix().await?;
     // get JSON bytes from stream
     let header: Vec<u8> = connection.read_body(prefix_len).await?;
-    // convert bytes into UTF-8 string
-    let string_header = String::from_utf8_lossy(&header);
-    // parse the JSON string back into a fileheader
-    let file_header: FileHeader = serde_json::from_str(&string_header)?;
+    // convert bytes into json
+    let file_header: FileHeader = serde_json::from_slice(&header)?;
 
     // extract size and hash from header
-    let received_size = file_header.size;
-    let received_hash = file_header.hash;
+    let (received_size, received_hash) = match file_header {
+        FileHeader::Upload { size, hash, .. } => (size, hash),
+        FileHeader::Error(e) => return Err(VeriflowError::ServerError(e)),
+        other => return Err(VeriflowError::UnexpectedFileHeader(format!("{:?}", other))),
+    };
 
     // Downloading to disk
 
@@ -231,11 +227,8 @@ pub async fn delete_file(path: &Path, ip: &str) -> common::Result<()> {
         .ok_or(VeriflowError::InvalidPath)?;
 
     // Setup FileHeader
-    let file_header: FileHeader = FileHeader {
-        command: Command::Delete,
+    let file_header: FileHeader = FileHeader::Delete {
         name: String::from(file_name),
-        size: 0,             // No size
-        hash: String::new(), // No hash
     };
 
     // Serialise the body
@@ -252,12 +245,11 @@ pub async fn delete_file(path: &Path, ip: &str) -> common::Result<()> {
     let prefix_len = connection.read_prefix().await?;
     // get JSON bytes from stream
     let header: Vec<u8> = connection.read_body(prefix_len).await?;
-    // convert bytes into UTF-8 string
-    let string_header = String::from_utf8_lossy(&header);
-    // parse the JSON string back into a fileheader
-    let file_header: FileHeader = serde_json::from_str(&string_header)?;
+    // convert bytes into json
+    let response: FileHeader = serde_json::from_slice(&header)?;
 
-    println!("{}", file_header.name);
+    // Check response
+    response.unpack_response()?;
 
     Ok(())
 }
@@ -274,12 +266,7 @@ pub async fn list_files(ip: &str) -> common::Result<()> {
     let mut connection = ProtocolConnection::new(stream).await?;
 
     // Setup FileHeader
-    let file_header: FileHeader = FileHeader {
-        command: Command::List,
-        name: String::new(), // No name
-        size: 0,             // No size
-        hash: String::new(), // No hash
-    };
+    let file_header: FileHeader = FileHeader::List;
 
     // Serialise the body
     // JSON string
@@ -295,13 +282,15 @@ pub async fn list_files(ip: &str) -> common::Result<()> {
     let prefix_len = connection.read_prefix().await?;
     // get JSON bytes from stream
     let header: Vec<u8> = connection.read_body(prefix_len).await?;
-    // convert bytes into UTF-8 string
-    let string_header = String::from_utf8_lossy(&header);
-    // parse the JSON string back into a fileheader
-    let file_header: FileHeader = serde_json::from_str(&string_header)?;
+    // convert bytes into json
+    let file_header: FileHeader = serde_json::from_slice(&header)?;
 
-    // get size
-    let received_size = file_header.size as usize;
+    // get size from enum
+    let received_size = match file_header {
+        FileHeader::Upload { size, .. } => size as usize,
+        FileHeader::Error(e) => return Err(VeriflowError::ServerError(e)),
+        other => return Err(VeriflowError::UnexpectedFileHeader(format!("{:?}", other))),
+    };
 
     // read payload (one-shot)
     let payload_bytes = connection.read_payload(received_size).await?;

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -52,31 +52,39 @@ pub enum FileHeader {
 // Error Type Struct for wrapping errors
 #[derive(Error, Debug)]
 pub enum VeriflowError {
-    // IO Error
+    /// IO Error
     #[error("Network/Disk Error: {0}")]
     Io(#[from] std::io::Error),
 
-    // JSON Error
+    /// JSON Error
     #[error("Serialisation Error: {0}")]
     JSON(#[from] serde_json::Error),
 
-    // File Path Error
+    /// File Path Error
     #[error("Invalid Path: Could not extract a valid filename from the provided path")]
     InvalidPath,
 
-    // Hash Mismatch Error
+    /// Hash Mismatch Error
     #[error("Hash Mismatch: The downloaded file was corrupted")]
     HashMismatch,
 
-    // Giant Header Error
+    /// Giant Header Error
     #[error("Security Alert: Requested header size {0} bytes exceeds the limit.")]
     HeaderSizeExceeded(usize),
 
-    // Giant Payload Error
+    /// Giant Payload Error
     #[error("Security Alert: Requested payload size {0} bytes exceeds the limit.")]
     PayloadSizeExceeded(usize),
 
-    //TOML Error
+    /// Unexpected File Header Error
+    #[error("Unexpected FileHeader: Received \"{0}\"")]
+    UnexpectedFileHeader(String),
+
+    /// Specific error message sent from server to client
+    #[error("Server Error: {0}")]
+    ServerError(String),
+
+    /// TOML Error
     #[error("Serialisation Error: {0}")]
     TOMLser(#[from] toml::ser::Error),
     #[error("Deserialisation Error: {0}")]

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -49,6 +49,21 @@ pub enum FileHeader {
     Error(String),
 }
 
+// FileHeader Server Response Logic
+impl FileHeader {
+    /// Check if the server to client header is a Success or an Error then handle it
+    pub fn unpack_response(self) -> Result<()> {
+        match self {
+            FileHeader::Success(msg) => {
+                println!("Server: {msg}");
+                Ok(())
+            }
+            FileHeader::Error(e) => Err(VeriflowError::ServerError(e)),
+            other => Err(VeriflowError::UnexpectedFileHeader(format!("{:?}", other))),
+        }
+    }
+}
+
 // Error Type Struct for wrapping errors
 #[derive(Error, Debug)]
 pub enum VeriflowError {

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -13,12 +13,33 @@ pub enum Command {
     List,     // Lists the directories from server's resource folder
 }
 
+// #[derive(Serialize, Deserialize, Debug, PartialEq)]
+// pub struct FileHeader {
+//     pub command: Command,
+//     pub name: String,
+//     pub size: u64,    
+//     pub hash: String, // hex string
+// }
+
+/// Primary header for the Veriflow protocol
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
-pub struct FileHeader {
-    pub command: Command,
-    pub name: String,
-    pub size: u64,    // u64 is standard for files
-    pub hash: String, // hex string
+#[serde(tag = "command", content = "data")]
+pub enum FileHeader {
+    Upload {
+        name: String,
+        size: u64,     // u64 is standard for files
+        hash: String   // hex string
+    },
+
+    Download {
+        name: String,
+    },
+
+    Delete {
+        name: String,
+    },
+
+    List,               // No data required
 }
 
 // Error Type Struct for wrapping errors

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -12,22 +12,18 @@ pub enum FileHeader {
     /// Upload file
     Upload {
         name: String,
-        size: u64,     // u64 is standard for files
-        hash: String   // hex string
+        size: u64,    // u64 is standard for files
+        hash: String, // hex string
     },
 
     /// Download file
-    Download {
-        name: String,
-    },
+    Download { name: String },
 
     /// Delete file
-    Delete {
-        name: String,
-    },
+    Delete { name: String },
 
     /// Lists the directories from server's resource folder
-    List,               // No data required
+    List, // No data required
 
     /// Server response to given request
     /// Success
@@ -48,6 +44,16 @@ impl FileHeader {
             }
             FileHeader::Error(e) => Err(VeriflowError::ServerError(e)),
             other => Err(VeriflowError::UnexpectedFileHeader(format!("{:?}", other))),
+        }
+    }
+
+    /// Helper to get the variant filename
+    pub fn path(&self) -> &str {
+        match self {
+            FileHeader::Upload { name, .. } => name,
+            FileHeader::Download { name } => name,
+            FileHeader::Delete { name } => name,
+            _ => "", // Other enums return empty string
         }
     }
 }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -40,6 +40,13 @@ pub enum FileHeader {
     },
 
     List,               // No data required
+
+    /// Server response to given request
+    /// Success
+    Success(String),
+
+    /// Failure, something went wrong server-side
+    Error(String),
 }
 
 // Error Type Struct for wrapping errors

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -5,40 +5,28 @@ use thiserror::Error;
 
 // cli command arg
 // PartialEQ for unit test
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
-pub enum Command {
-    Upload,   // Upload file
-    Download, // Download file
-    Delete,   // Delete file
-    List,     // Lists the directories from server's resource folder
-}
-
-// #[derive(Serialize, Deserialize, Debug, PartialEq)]
-// pub struct FileHeader {
-//     pub command: Command,
-//     pub name: String,
-//     pub size: u64,    
-//     pub hash: String, // hex string
-// }
-
 /// Primary header for the Veriflow protocol
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 #[serde(tag = "command", content = "data")]
 pub enum FileHeader {
+    /// Upload file
     Upload {
         name: String,
         size: u64,     // u64 is standard for files
         hash: String   // hex string
     },
 
+    /// Download file
     Download {
         name: String,
     },
 
+    /// Delete file
     Delete {
         name: String,
     },
 
+    /// Lists the directories from server's resource folder
     List,               // No data required
 
     /// Server response to given request
@@ -120,8 +108,7 @@ mod tests {
         let file_name: &str = "img.png";
 
         // instantiate file header
-        let original_file_header: FileHeader = FileHeader {
-            command: Command::Download,
+        let original_file_header = FileHeader::Upload {
             name: String::from(file_name),
             size: 4001,
             hash: String::from("abc123def"),
@@ -133,6 +120,7 @@ mod tests {
 
         // test if file name is inside of json
         assert!(json_string.contains(file_name));
+        assert!(json_string.contains("Upload"));
 
         // Deserialise (String -> Struct)
         let deserialised_json_wrapped = serde_json::from_str(&json_string);

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -21,7 +21,7 @@ pub struct Directory {
 mod test {
     use crate::server::Listener;
     pub use common::protocol::ProtocolConnection;
-    pub use common::{Command, FileHeader};
+    pub use common::FileHeader;
     use tokio::net::TcpStream;
     #[tokio::test]
     async fn test_protocol_read_and_write(
@@ -48,8 +48,7 @@ mod test {
         let file_name: &str = "img.png";
 
         // instantiate file header
-        let original_file_header: FileHeader = FileHeader {
-            command: Command::Download,
+        let original_file_header = FileHeader::Upload {
             name: String::from(file_name),
             size: 4001,
             hash: String::from("abc123def"),

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -1,8 +1,4 @@
-use common::hashing;
-use common::protocol::ProtocolConnection;
-use common::Command;
-use common::FileHeader;
-use common::VeriflowError;
+use common::{hashing, protocol::ProtocolConnection, FileHeader, VeriflowError};
 use std::io;
 use std::path;
 use std::path::{Component, Path, PathBuf};
@@ -92,7 +88,7 @@ impl Listener {
         let header: Vec<u8> = connection.read_body(prefix_len).await?;
         let string_header = String::from_utf8_lossy(&header);
         let file_header: FileHeader = serde_json::from_str(&string_header)?;
-        Self::handle_operation(&file_header, connection, path).await?;
+        Self::handle_operation(file_header, connection, path).await?;
         Ok(())
     }
     async fn safe_join(base: &Path, user_input: &str) -> common::Result<path::PathBuf> {
@@ -118,59 +114,48 @@ impl Listener {
     }
     ///Function to manage the client operations
     async fn handle_operation(
-        header: &FileHeader,
+        header: FileHeader,
         connection: ProtocolConnection,
         path: PathBuf,
     ) -> common::Result<()> {
-        let operation = &header.command;
-        let path_var = path.as_path();
-        let safe_path = Self::safe_join(path_var, &header.name).await?;
-        match operation {
-            Command::Upload => {
-                Self::handle_upload(header, connection, safe_path).await?;
+        // Get path
+        let path_var = header.path();
+        let safe_path = Self::safe_join(path.as_path(), path_var).await?;
+
+        match header {
+            FileHeader::Upload { size, hash, .. } => {
+                Self::handle_upload(connection, safe_path, size, hash).await?
             }
-            Command::Download => {
-                Self::handle_download(header, connection, safe_path).await?;
-            }
-            Command::List => {
-                Self::handle_list(connection, safe_path).await?;
-            }
-            Command::Delete => {
-                Self::handle_delete(connection, safe_path).await?;
-            }
+            FileHeader::Download { .. } => Self::handle_download(connection, safe_path).await?,
+            FileHeader::Delete { .. } => Self::handle_delete(connection, safe_path).await?,
+            FileHeader::List => Self::handle_list(connection, safe_path).await?,
+            // Error handling for wrong variants
+            other => return Err(VeriflowError::UnexpectedFileHeader(format!("{:?}", other))),
         }
         Ok(())
     }
     ///Handles clients' upload operation
     async fn handle_upload(
-        header: &FileHeader,
         mut connection: ProtocolConnection,
         path: PathBuf,
+        size: u64,
+        expected_hash: String,
     ) -> common::Result<()> {
-        let mut received_file = File::create(&path.as_path()).await?;
+        let mut received_file = File::create(&path).await?;
         connection
-            .read_file_to_disk(&mut received_file, header.size)
+            .read_file_to_disk(&mut received_file, size)
             .await?;
         let received_file_hash = hashing::hash_file(path.as_path(), |_| {}).await?;
-        if header.hash != received_file_hash {
+
+        if expected_hash != received_file_hash {
             fs::remove_file(path).await?;
             error!("There has been an error when comparing the expected hash to the calculated hash retry sending the file");
-            let header = FileHeader {
-                command: Command::Upload,
-                name: "Failure hash does not match".to_string(),
-                size: 0,
-                hash: ' '.to_string(),
-            };
+            let header = FileHeader::Error("Failure: Hash didn't match!".to_string());
             let str_header = serde_json::to_string(&header)?;
             connection.send_header(&str_header).await?;
         } else {
             info!("File successfuly received");
-            let header = FileHeader {
-                command: Command::Delete,
-                name: "Success".to_string(),
-                size: 0,
-                hash: ' '.to_string(),
-            };
+            let header = FileHeader::Success("File uploaded successfully!".to_string());
             let str_header = serde_json::to_string(&header)?;
             connection.send_header(&str_header).await?;
         }
@@ -178,21 +163,26 @@ impl Listener {
     }
     ///Handles a clients' download request
     async fn handle_download(
-        header: &FileHeader,
         mut connection: ProtocolConnection,
         path: PathBuf,
     ) -> common::Result<()> {
-        let filename: String = header.name.clone();
+        // Extract filename from PathBuf
+        let filename = path
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_else(|| "download".to_string());
+
         let mut file_to_send = File::open(&path.as_path()).await?;
         let file_meta_data = fs::metadata(&path.as_path()).await?;
         let file_size = file_meta_data.len();
         let file_hash = hashing::hash_file(path.as_path(), |_| {}).await?; // use saved .sha256 sidecar file in future
-        let file_header = FileHeader {
-            command: Command::Upload,
+
+        let file_header = FileHeader::Upload {
             name: filename,
             size: file_size,
             hash: file_hash,
         };
+
         let serialized_header = serde_json::to_string(&file_header)?;
         connection.send_header(&serialized_header).await?;
         connection
@@ -225,11 +215,10 @@ impl Listener {
         }
         info!("{:?}", path_list);
         let payload = serde_json::to_vec(&path_list)?;
-        let payload_header = FileHeader {
-            command: Command::List,
+        let payload_header = FileHeader::Upload {
             name: "list".to_string(),
             size: payload.len() as u64,
-            hash: ' '.to_string(),
+            hash: String::new(),
         };
         let str_header = serde_json::to_string(&payload_header)?;
         connection.send_header(&str_header).await?;
@@ -243,53 +232,23 @@ impl Listener {
     ) -> common::Result<()> {
         info!("{:?}", &path);
         let md = metadata(&path).await?;
-        if md.is_dir() {
-            match fs::remove_dir_all(path.as_path()).await {
-                Ok(()) => {
-                    let header = FileHeader {
-                        command: Command::Delete,
-                        name: "Success".to_string(),
-                        size: 0,
-                        hash: ' '.to_string(),
-                    };
-                    let str_header = serde_json::to_string(&header)?;
-                    connection.send_header(&str_header).await?;
-                }
-                Err(e) => {
-                    let header = FileHeader {
-                        command: Command::Delete,
-                        name: format!("Failed with error {e}").to_string(),
-                        size: 0,
-                        hash: ' '.to_string(),
-                    };
-                    let str_header = serde_json::to_string(&header)?;
-                    connection.send_header(&str_header).await?;
-                }
+
+        // combine the fs::remove logic for directories and files
+        let result = if md.is_dir() {
+            fs::remove_dir_all(&path).await
+        } else {
+            fs::remove_file(&path).await
+        };
+
+        let response_header = match result {
+            Ok(()) => {
+                FileHeader::Success("Successfully deleted the requested file/folder".to_string())
             }
-        } else if md.is_file() {
-            match fs::remove_file(path.as_path()).await {
-                Ok(()) => {
-                    let header = FileHeader {
-                        command: Command::Delete,
-                        name: "Success".to_string(),
-                        size: 0,
-                        hash: ' '.to_string(),
-                    };
-                    let str_header = serde_json::to_string(&header)?;
-                    connection.send_header(&str_header).await?;
-                }
-                Err(e) => {
-                    let header = FileHeader {
-                        command: Command::Delete,
-                        name: format!("Failed with error {e}").to_string(),
-                        size: 0,
-                        hash: ' '.to_string(),
-                    };
-                    let str_header = serde_json::to_string(&header)?;
-                    connection.send_header(&str_header).await?;
-                }
-            }
-        }
+            Err(e) => FileHeader::Error(format!("Failed to delete: {e}")),
+        };
+
+        let str_header = serde_json::to_string(&response_header)?;
+        connection.send_header(&str_header).await?;
 
         Ok(())
     }


### PR DESCRIPTION
- Enum protocol: replaced redundant Command enum and empty struct fields with a unified FileHeader enum
- Added Success(String) and Error(String) variants
- Helper functions in `impl FileHeader` for safely extracting routing path and unpacking the server Success/Failure response to client
-  Updated tests to match new enum syntax
- refactored handle_operation to remove redundancy via pattern matching