### PR TITLE
Feat/client/connection error

### DIFF
--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -20,11 +20,7 @@ async fn main() -> Result<(), VeriflowError> {
     // Handle CLI arguments
     match args.command {
         // Config
-        Commands::Config { 
-            ip, 
-            port, 
-            dir 
-        } => {
+        Commands::Config { ip, port, dir } => {
             if let Some(new_ip) = ip {
                 config.ip = new_ip;
             }
@@ -54,20 +50,33 @@ async fn main() -> Result<(), VeriflowError> {
             // Use Some operator for Option
             if let Some(path) = upload {
                 // Upload
-                transfer::upload_file(&path, &target_ip).await?;
+                handle_result(transfer::upload_file(&path, &target_ip).await);
             } else if let Some(path) = download {
                 // Download
-                transfer::download_file(&path, &target_ip, &config.download_dir).await?;
+                handle_result(
+                    transfer::download_file(&path, &target_ip, &config.download_dir).await,
+                );
             } else if let Some(path) = delete {
                 // Delete
-                transfer::delete_file(&path, &target_ip).await?;
+                handle_result(transfer::delete_file(&path, &target_ip).await);
             } else if list {
                 // List
-                transfer::list_files(&target_ip).await?;
+                handle_result(transfer::list_files(&target_ip).await);
             };
 
             println!("Success!");
         }
     }
     Ok(())
+}
+
+// transfer fn wrapper for error handling
+fn handle_result<T>(result: common::Result<T>) -> T {
+    match result {
+        Ok(val) => val,
+        Err(e) => {
+            eprintln!("{}", e);
+            std::process::exit(1)
+        }
+    }
 }

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -20,7 +20,11 @@ async fn main() -> Result<(), VeriflowError> {
     // Handle CLI arguments
     match args.command {
         // Config
-        Commands::Config { ip, port, dir } => {
+        Commands::Config { 
+            ip, 
+            port, 
+            dir 
+        } => {
             if let Some(new_ip) = ip {
                 config.ip = new_ip;
             }

--- a/client/src/transfer.rs
+++ b/client/src/transfer.rs
@@ -13,6 +13,20 @@ use tokio::net::TcpStream;
 use comfy_table::presets::NOTHING;
 use comfy_table::Table;
 
+/// Helper function for establishing a connection
+async fn connect_to_server(ip: &str) -> common::Result<ProtocolConnection> {
+    println!("Connecting to {ip}...");
+    
+    // connect via TCP stream, intercept io::Error for connection VeriflowError 
+    let stream = TcpStream::connect(ip).await.map_err(|e| VeriflowError::ConnectionFailed {
+        ip: ip.to_string(),
+        source: e,
+    })?;
+
+    // move ownership of stream into ProtocolConnection
+    Ok(ProtocolConnection::new(stream).await?)
+}
+
 /// Upload to Server
 pub async fn upload_file(path: &Path, ip: &str) -> common::Result<()> {
     // Offline Logic (Validation)
@@ -45,14 +59,8 @@ pub async fn upload_file(path: &Path, ip: &str) -> common::Result<()> {
 
     println!("File Hash: {file_hash}");
 
-    // Connect to server
-    println!("Connecting to {ip}...");
-
-    // connect via TCP stream
-    let stream = TcpStream::connect(ip).await?;
-
-    // move ownership of stream into ProtocolConnection
-    let mut connection = ProtocolConnection::new(stream).await?;
+    // connect to server
+    let mut connection = connect_to_server(ip).await?;
 
     // Setup FileHeader
     let file_header: FileHeader = FileHeader::Upload {
@@ -122,14 +130,8 @@ pub async fn upload_file(path: &Path, ip: &str) -> common::Result<()> {
 
 /// Download from Server
 pub async fn download_file(path: &Path, ip: &str, download_dir: &Path) -> common::Result<()> {
-    // Connect to server
-    println!("Connecting to {ip}...");
-
-    // connect via TCP stream
-    let stream = TcpStream::connect(ip).await?;
-
-    // move ownership of stream into ProtocolConnection
-    let mut connection = ProtocolConnection::new(stream).await?;
+    // connect to server
+    let mut connection = connect_to_server(ip).await?;
 
     // get file name -- Strict error handling (Allow ONLY UTF-8 characters)
     let file_name = path
@@ -223,14 +225,8 @@ pub async fn download_file(path: &Path, ip: &str, download_dir: &Path) -> common
 
 /// Delete from Server
 pub async fn delete_file(path: &Path, ip: &str) -> common::Result<()> {
-    // Connect to server
-    println!("Connecting to {ip}...");
-
-    // connect via TCP stream
-    let stream = TcpStream::connect(ip).await?;
-
-    // move ownership of stream into ProtocolConnection
-    let mut connection = ProtocolConnection::new(stream).await?;
+    // connect to server
+    let mut connection = connect_to_server(ip).await?;
 
     // get file name -- Strict error handling (Allow ONLY UTF-8 characters)
     let file_name = path
@@ -268,14 +264,8 @@ pub async fn delete_file(path: &Path, ip: &str) -> common::Result<()> {
 
 /// List Server Files
 pub async fn list_files(ip: &str) -> common::Result<()> {
-    // Connect to server
-    println!("Connecting to {ip}...");
-
-    // connect via TCP stream
-    let stream = TcpStream::connect(ip).await?;
-
-    // move ownership of stream into ProtocolConnection
-    let mut connection = ProtocolConnection::new(stream).await?;
+    // connect to server
+    let mut connection = connect_to_server(ip).await?;
 
     // Setup FileHeader
     let file_header: FileHeader = FileHeader::List;

--- a/client/src/transfer.rs
+++ b/client/src/transfer.rs
@@ -16,15 +16,17 @@ use comfy_table::Table;
 /// Helper function for establishing a connection
 async fn connect_to_server(ip: &str) -> common::Result<ProtocolConnection> {
     println!("Connecting to {ip}...");
-    
-    // connect via TCP stream, intercept io::Error for connection VeriflowError 
-    let stream = TcpStream::connect(ip).await.map_err(|e| VeriflowError::ConnectionFailed {
-        ip: ip.to_string(),
-        source: e,
-    })?;
+
+    // connect via TCP stream, intercept io::Error for connection VeriflowError
+    let stream = TcpStream::connect(ip)
+        .await
+        .map_err(|e| VeriflowError::ConnectionFailed {
+            ip: ip.to_string(),
+            source: e,
+        })?;
 
     // move ownership of stream into ProtocolConnection
-    Ok(ProtocolConnection::new(stream).await?)
+    ProtocolConnection::new(stream).await
 }
 
 /// Upload to Server

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -66,7 +66,7 @@ pub enum VeriflowError {
     Io(#[from] std::io::Error),
 
     /// Connection Error
-    #[error("Could not connect at {ip}. Details: {source}")]
+    #[error("Could not connect to {ip}. Details: {source}")]
     ConnectionFailed {
         ip: String,
         #[source]

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -65,6 +65,14 @@ pub enum VeriflowError {
     #[error("Network/Disk Error: {0}")]
     Io(#[from] std::io::Error),
 
+    /// Connection Error
+    #[error("Could not connect at {ip}. Details: {source}")]
+    ConnectionFailed {
+        ip: String,
+        #[source]
+        source: std::io::Error,
+    },
+
     /// JSON Error
     #[error("Serialisation Error: {0}")]
     JSON(#[from] serde_json::Error),


### PR DESCRIPTION
- add new VeriflowError error for failed connection with ip and error description
- implement `connect_to_server` function in `transfer.rs` for a unified connection logic
- add wrapper function to `main.rs` to handle all connection errors for each function
- closes #84